### PR TITLE
Money\Money is allowed to have nullable values

### DIFF
--- a/src/Model/Mapping/Money.Money.php
+++ b/src/Model/Mapping/Money.Money.php
@@ -4,10 +4,12 @@ $metadata->isEmbeddedClass = true;
 
 $metadata->mapField(array(
     'fieldName' => 'amount',
-    'type' => 'integer'
+    'type' => 'integer',
+    'nullable' => true
 ));
 
 $metadata->mapField(array(
     'fieldName' => 'currency',
-    'type' => 'currency'
+    'type' => 'currency',
+    'nullable' => true
 ));


### PR DESCRIPTION
If you have an entity, that could have a price (optional), and the price is represented as an instance of Money\Money, as Embedded Entity.
Then it will create a db schema with all fields (price_amout, price_currency) but these fields are nullable = FALSE by default, so the price is not possible to track as OPTIONAL property of an entity.

In order to solve that, I propose to allow nullables.
