### PR TITLE
fix coverage settings

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,9 +17,8 @@
         </testsuite>
     </testsuites>
     <filter>
-        <blacklist>
-              <directory>./vendor</directory>
-              <file>./bootstrap.php</file>
-        </blacklist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
Fix the coverage calc by setting all .php files in whitelist. The current calc is considering only files used in tests.