### PR TITLE
Require Doctrine\ORM 2.5 minimum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=5.5",
         "doctrine/doctrine-module": "~0.8",
-        "doctrine/orm": "~2.5",
+        "doctrine/orm": "^2.5",
         "zendframework/zend-form": "~2.3",
         "zendframework/zend-filter": "~2.3",
         "zendframework/zend-validator": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=5.5",
         "doctrine/doctrine-module": "~0.8",
-        "doctrine/orm": ">=2.5",
+        "doctrine/orm": "~2.5",
         "zendframework/zend-form": "~2.3",
         "zendframework/zend-filter": "~2.3",
         "zendframework/zend-validator": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require": {
         "php": ">=5.5",
         "doctrine/doctrine-module": "~0.8",
+        "doctrine/orm": ">=2.5",
         "zendframework/zend-form": "~2.3",
         "zendframework/zend-filter": "~2.3",
         "zendframework/zend-validator": "~2.3",


### PR DESCRIPTION
I just tried installing this module, and i had orm 2.4.x, but i got no error. 
This module requires orm 2.5 minimum, as it's using embeddables.
